### PR TITLE
Fixed closure syntax error in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $app->register(new Ghostscript\GhostscriptServiceProvider(), array(
         'gs.binaries' => '/usr/bin/gs',
         'timeout'     => 42,
     )
-    'ghostscript.logger' => $app->share(function () {
+    'ghostscript.logger' => $app->share(function () use ($app) {
         return $app['monolog']; // use Monolog service provider
     }),
 ));


### PR DESCRIPTION
Added required use to Silex closure in the Silex service provider documentation.