### PR TITLE
Fixed reference to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $app->register(new Ghostscript\GhostscriptServiceProvider(), array(
     }),
 ));
 
-$app['ghostscript.pdf-transcoder']->toImage('document.pdf', 'image.jpg');
+$app['ghostscript.transcoder']->toImage('document.pdf', 'image.jpg');
 ```
 
 # License


### PR DESCRIPTION
Fixed documentation for Silex service provider usage

* Service provider register sets transcoder service to key: "ghostscript.transcoder"
  where the documentation references a different key.